### PR TITLE
Fix: GitHub Readme Activity Graph fixed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Hi, I am Kaiwalya! Great to see you here! 👋
 
-I am Kaiwalya Koparkar, CNCF Ambassadors, PM at WeMakeDevs, Project Maintainer at EddieHubCommunity, GCE 🚩, and MLH Coach. I am a Full Stack Developer with experience building open source projects. I am a tech enthusiast & an open-source advocate. I am always open to collaborating on projects and innovative/disruptive ideas. Find out more about me & feel free to connect with me here:
+I am Kaiwalya Koparkar, CNCF Ambassador, PM at WeMakeDevs, Project Maintainer at EddieHubCommunity, GCE 🚩, and MLH Coach. I am a Full Stack Developer with experience building open-source projects. I am a tech enthusiast & an open-source advocate. I am always open to collaborating on projects and innovative/disruptive ideas. Find out more about me & feel free to connect with me here:
 
 [![Linkedin Badge](https://img.shields.io/badge/-kaiwalyakoparkar-blue?style=flat-square&logo=Linkedin&logoColor=white&link=https://www.linkedin.com/in/kaiwalyakoparkar/)](https://www.linkedin.com/in/kaiwalyakoparkar/)
 [![Instagram Badge](https://img.shields.io/badge/-kaiwalya.koparkar-purple?style=flat-square&logo=instagram&logoColor=white&link=https://instagram.com/kaiwalya.koparkar/)](https://instagram.com/kaiwalya.koparkar)
@@ -9,7 +9,7 @@ I am Kaiwalya Koparkar, CNCF Ambassadors, PM at WeMakeDevs, Project Maintainer a
 [![Website Badge](https://img.shields.io/badge/-Portfolio-black?style=flat-square&logo=Wordpress&logoColor=white&link=https://kaiwalyakoparkar.github.io/)](https://kaiwalyakoparkar.github.io/)
 [![Youtube Badge](https://img.shields.io/badge/-Kaiwalya%20Koparkar-darkred?style=flat-square&logo=youtube&logoColor=white&link=https://www.youtube.com/channel/UCZow8pOHiyz26yl4Da-Mfzw)](https://www.youtube.com/channel/UCZow8pOHiyz26yl4Da-Mfzw)
 
-[![Kaiwalya's github activity graph](https://github-readme-activity-graph.cyclic.app/graph?username=kaiwalyakoparkar&bg_color=0f2d3d&color=1cadfb&line=1cadfb&point=1cadfb&area=true&hide_border=true")](https://github.com/ashutosh00710/github-readme-activity-graph)
+[![Kaiwalya's github activity graph](https://github-readme-activity-graph.vercel.app/graph?username=kaiwalyakoparkar&bg_color=0f2d3d&color=1cadfb&line=1cadfb&point=1cadfb&area=true&hide_border=true)](https://github.com/ashutosh00710/github-readme-activity-graph)
 
 ## ⚡ Technologies
 


### PR DESCRIPTION
First of all your **GitHub Activity Graph** was not visible.

![image](https://github.com/kaiwalyakoparkar/kaiwalyakoparkar/assets/79737447/1e505b03-a562-46dc-b0f6-cb77197b89f5)

So I thought, there must be a mistake and I found 1 mistake is that one typo error in that Link.
You can see that in `diff`. Then also it was not visible so finally I change your **Activity Graph Link** from `cyclic.app` to `vercel.app`.

Finally, then it starts showing your **Activity Graph**.

# What chages I made:
- fix the Activity Graph link.
- correct some typo errors.